### PR TITLE
Setting Acls fails if AAD has duplicate groups #33

### DIFF
--- a/adls2.folder.access.tools.Tests/Set-FatAdlsAcEntryOnItem.Tests.ps1
+++ b/adls2.folder.access.tools.Tests/Set-FatAdlsAcEntryOnItem.Tests.ps1
@@ -1,0 +1,40 @@
+param($ModulePath, $config)
+BeforeAll {
+    $CommandName = 'Set-FatAdlsAclEntryOnItem.ps1'
+    if (-not $ModulePath) { $ModulePath = join-path (join-path $PSScriptRoot "..") "adls2.folder.access.tools" }
+    
+    Get-Module adls2.folder.access.tools | remove-module -Force
+    $CommandNamePath = Resolve-Path (Join-Path $ModulePath /Private/$CommandName)
+    Import-Module $CommandNamePath -Force
+
+    . (Join-Path $ModulePath "Private" "Get-FatCachedAdGroupId.ps1" )
+    . (Join-Path $ModulePath "Private" "Get-FatCachedAdGroupName.ps1")
+}
+
+AfterAll {
+}
+
+Describe "Set-FatAdlsAclEntryOnItem" -Tag 'Integration' {
+    BeforeAll{
+    }
+    Context "Can handle duplicate groups in AAD" {
+        It "Will Not Throw" {
+            Mock Get-AzDataLakeGen2Item { @{Acl=new-object Collections.Generic.List[System.Object] }  }
+            Mock set-AzDataLakeGen2ItemAclObject {@()}
+            Mock Update-AzDataLakeGen2Item 
+            Mock Update-AzDataLakeGen2AclRecursive
+            Mock Get-FatCachedAdGroupName {"foo"}
+            Mock  Get-FatCachedAdGroupId {@(@{Id=New-Guid},@{Id=New-Guid})}
+            $ctx = New-AzStorageContext "ds" -Anonymous
+
+$entry= [PSCustomObject]@{Container = "ContainerName"; Folder = "FolderName"; Items = @(@{ADGroup="SomGroup";DefaultPermission="rwx";AccessPermission="rwx"}) }
+
+            {Set-FatAdlsAclEntryOnItem -subscriptionName "Name Of Subscription"  `
+                -dataLakeStoreName "data lake store name"  `
+                -aclEntry $entry `
+                -ctx $ctx } | should -Throw "Cannot determine group. Found 2 duplicate entries. See previous output for resolution options."
+
+                
+                }
+    }
+}

--- a/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
+++ b/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
@@ -58,13 +58,11 @@ Function Set-FatAdlsAclEntryOnItem {
                 Write-Verbose "Getting the GroupId from AAD"
                 $ADGroup = Get-FatCachedAdGroupId -DisplayName $acl.ADGroup
                 if (@($AdGroup).Count -eq 1){
-                    $ADGroupId = $.CountADGroup.Id
+                    $ADGroupId = $ADGroup.Id
                 }
                 else{
                     Write-Host "$($AdGroup.Count) entries found for group ($($acl.ADGroup)). Pick the right groupId from the list below and specify it directly in the Acl entry"
-                    for ($i = 0; $i -lt $AdGroup.Count; $i++) {
-                        
-                    }($Id..1)| ForEach-Object{Write-Host "  Duplicate $_ : $($AdGroup[$_].Id)" }
+                    (0..($AdGroup.Count-1))| ForEach-Object{Write-Host "  Duplicate $_ : $($AdGroup[$_].Id)" }
                     Throw "Cannot determine group. Found $($AdGroup.Count) duplicate entries. See previous output for resolution options."
                 }
             }
@@ -154,7 +152,6 @@ Function Set-FatAdlsAclEntryOnItem {
         }
     }
     catch {
-        Write-Error $_
         Throw
     }
 }

--- a/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
+++ b/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
@@ -61,8 +61,11 @@ Function Set-FatAdlsAclEntryOnItem {
                     $ADGroupId = $.CountADGroup.Id
                 }
                 else{
-                    Write-Host "$($AdGroup.Count) entries found for group ($($acl.ADGroup)), this entry will be ignored. To pick one of the groups specify the ADGroupId in the Acl entry"
-                    $AdGroupId = $null
+                    Write-Host "$($AdGroup.Count) entries found for group ($($acl.ADGroup)). Pick the right groupId from the list below and specify it directly in the Acl entry"
+                    for ($i = 0; $i -lt $AdGroup.Count; $i++) {
+                        
+                    }($Id..1)| ForEach-Object{Write-Host "  Duplicate $_ : $($AdGroup[$_].Id)" }
+                    Throw "Cannot determine group. Found $($AdGroup.Count) duplicate entries. See previous output for resolution options."
                 }
             }
             if ($null -ne $AdGroupId){

--- a/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
+++ b/adls2.folder.access.tools/Private/Set-FatAdlsAclEntryOnItem.ps1
@@ -57,19 +57,27 @@ Function Set-FatAdlsAclEntryOnItem {
             else {
                 Write-Verbose "Getting the GroupId from AAD"
                 $ADGroup = Get-FatCachedAdGroupId -DisplayName $acl.ADGroup
-                $ADGroupId = $ADGroup.Id
+                if (@($AdGroup).Count -eq 1){
+                    $ADGroupId = $.CountADGroup.Id
+                }
+                else{
+                    Write-Host "$($AdGroup.Count) entries found for group ($($acl.ADGroup)), this entry will be ignored. To pick one of the groups specify the ADGroupId in the Acl entry"
+                    $AdGroupId = $null
+                }
             }
-            if (-not [string]::IsNullOrWhitespace($acl.DefaultPermission)) {
-                $aclCountBefore = $aclList.Count
-                Write-Verbose "Adding Default Acl $($acl.DefaultPermission) for $AdGroupId ($($acl.AdGroup))"
-                $aclList = set-AzDataLakeGen2ItemAclObject -AccessControlType group -EntityID $AdGroupId  -Permission $acl.DefaultPermission -InputObject $aclList -DefaultScope 
-                Write-Verbose "Count of Acls before and After $aclCountBefore-$($AclList.Count) "
-            }
-            if ( -not [string]::IsNullOrWhitespace($acl.AccessPermission)) {
-                $aclCountBefore = $aclList.Count
-                Write-Verbose "Adding Access Acl $($acl.AccessPermission) for $AdGroupId ($($acl.AdGroup))"
-                $aclList = set-AzDataLakeGen2ItemAclObject -AccessControlType group -EntityID $AdGroupId  -Permission $acl.AccessPermission -InputObject $aclList
-                Write-Verbose "Count of Acls before and After $aclCountBefore-$($AclList.Count) "
+            if ($null -ne $AdGroupId){
+                if (-not [string]::IsNullOrWhitespace($acl.DefaultPermission)) {
+                    $aclCountBefore = $aclList.Count
+                    Write-Verbose "Adding Default Acl $($acl.DefaultPermission) for $AdGroupId ($($acl.AdGroup))"
+                    $aclList = set-AzDataLakeGen2ItemAclObject -AccessControlType group -EntityID $AdGroupId  -Permission $acl.DefaultPermission -InputObject $aclList -DefaultScope 
+                    Write-Verbose "Count of Acls before and After $aclCountBefore-$($AclList.Count) "
+                }
+                if ( -not [string]::IsNullOrWhitespace($acl.AccessPermission)) {
+                    $aclCountBefore = $aclList.Count
+                    Write-Verbose "Adding Access Acl $($acl.AccessPermission) for $AdGroupId ($($acl.AdGroup))"
+                    $aclList = set-AzDataLakeGen2ItemAclObject -AccessControlType group -EntityID $AdGroupId  -Permission $acl.AccessPermission -InputObject $aclList
+                    Write-Verbose "Count of Acls before and After $aclCountBefore-$($AclList.Count) "
+                }
             }
         }
      

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -65,7 +65,7 @@ steps:
   - task: PowerShell@2
     displayName: "PowerShell Pester Tests "
     inputs:
-      targetType: "inline"
+      targetType: 'inline'
       script: |
         Install-Module Az -Scope CurrentUser -Force -Verbose -MinimumVersion 5.3.0
         $credential = New-Object System.Management.Automation.PSCredential ("${env:SPID}", (ConvertTo-SecureString ${env:SPKEY} -AsPlainText -Force))
@@ -81,6 +81,7 @@ steps:
         -OutputFile "$Edition-TestResults.xml" `
         -OutputFormat NUnitXML `
         -CodeCoverageOutputFile "coverage-$Edition-results.xml"
+      ignoreLASTEXITCODE: true
       pwsh: true
 
 


### PR DESCRIPTION
Put more verbose output to handle when multiple groups exist in AAD and provide guidance #33